### PR TITLE
feat: アクティブウィンドウ取得AppleScriptの実装 (#2)

### DIFF
--- a/scripts/screenshot_window.applescript
+++ b/scripts/screenshot_window.applescript
@@ -1,0 +1,11 @@
+#!/usr/bin/osascript
+
+-- アクティブなウィンドウのアプリケーション名を取得
+try
+    tell application "System Events"
+        set active_app to name of first process whose frontmost is true
+        return active_app
+    end tell
+on error
+    return "Unknown"
+end try


### PR DESCRIPTION
## 概要
Issue #2 の対応：現在アクティブなウィンドウのアプリケーション名を取得するAppleScriptを実装しました。

## 実装内容
- ✅ System Events経由でフロントモストプロセス名を取得
- ✅ エラー時は "Unknown" を返すエラーハンドリング
- ✅ osascript shebang追加で直接実行可能

## AppleScript コード
```applescript
#!/usr/bin/osascript

try
    tell application "System Events"
        set active_app to name of first process whose frontmost is true
        return active_app
    end tell
on error
    return "Unknown"
end try
```

## 動作確認
```bash
$ osascript scripts/screenshot_window.applescript
Electron  # 現在アクティブなアプリケーション名が出力される

$ ./scripts/screenshot_window.applescript
Electron  # shebangで直接実行も可能
```

## テスト結果
- [x] アクティブウィンドウ名を正常に取得できる
- [x] エラーハンドリングが実装されている
- [x] 実行権限が付与されている

## 次のステップ
このスクリプトは Issue #5 (メインOCRスクリプト) で使用されます。

Closes #2