### PR TITLE
feat: enhance pyproject.toml metadata for PyPI distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,21 +3,46 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "screenocr-logger"
+name = "screen-times"
 version = "0.1.0"
-description = "macOS screen OCR logger using Vision Framework"
+description = "macOS screen activity logger with OCR using Vision Framework"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "MIT"}
+license = "MIT"
+keywords = ["ocr", "screenshot", "macos", "logging", "productivity", "vision-framework", "activity-tracking"]
 authors = [
-    {name = "Kobori Akira", email = "akira@example.com"}
+    {name = "Kobori Akira", email = "private.beats@gmail.com"}
+]
+maintainers = [
+    {name = "Kobori Akira", email = "private.beats@gmail.com"}
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: MacOS X",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: Developers",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Desktop Environment :: Screen Savers",
+    "Topic :: System :: Logging",
+    "Topic :: Utilities",
 ]
 
 dependencies = [
-    "pyobjc-framework-Cocoa>=12.0",
-    "pyobjc-framework-Vision>=12.0",
-    "pyobjc-framework-Quartz>=12.0",
+    "pyobjc-framework-Cocoa>=12.0; sys_platform == 'darwin'",
+    "pyobjc-framework-Vision>=12.0; sys_platform == 'darwin'",
+    "pyobjc-framework-Quartz>=12.0; sys_platform == 'darwin'",
 ]
+
+[project.urls]
+Homepage = "https://github.com/koboriakira/screen-times"
+Repository = "https://github.com/koboriakira/screen-times"
+Issues = "https://github.com/koboriakira/screen-times/issues"
+Changelog = "https://github.com/koboriakira/screen-times/releases"
 
 [project.scripts]
 screenocr = "screen_times.cli:main"


### PR DESCRIPTION
## 概要

Issue #26 の対応です。PyPI公開に向けて `pyproject.toml` のメタデータを充実させました。

## 変更内容

### パッケージ情報の更新
- **パッケージ名**: `screen-times` に変更（PyPI命名規則に準拠）
- **キーワード追加**: ocr, screenshot, macos, logging, productivity, vision-framework, activity-tracking
- **メンテナー情報追加**: 作者とメンテナーの情報を明記

### メタデータの追加
- **Classifiers**: 開発状況、対象ユーザー、トピックなどを分類
  - Development Status: Alpha
  - Environment: MacOS X
  - Operating System: MacOS
  - Programming Language: Python 3.9-3.12
- **プロジェクトURL**: Homepage, Repository, Issues, Changelogを追加

### ライセンス表記の改善
- **SPDX形式に変更**: `license = "MIT"` に更新
- **非推奨の classifier を削除**: `License :: OSI Approved :: MIT License` を削除
- これにより setuptools の非推奨警告が解消されました

### プラットフォーム対応
- **macOS専用の依存関係**: PyObjC frameworks に `sys_platform == 'darwin'` マーカーを追加
- これにより非macOS環境でのインストール時にエラーが発生しません

## 動作確認

```bash
python -m build --wheel --outdir /tmp/build-test
```

✅ パッケージのビルドが成功し、警告なしで完了することを確認しました

## 関連Issue

Closes #26

## 次のステップ

Phase 2の残りタスク (#30) として、README.mdのPyPI向け更新を実施します。