### PR TITLE
ci: TestPyPI自動公開ワークフローを追加

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,0 +1,41 @@
+# @format
+
+name: Publish to TestPyPI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # 手動実行も可能
+
+jobs:
+  publish-test:
+    name: Publish package to TestPyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package
+        run: twine check dist/*
+
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          twine upload --repository testpypi dist/*


### PR DESCRIPTION
## 概要
Issue #40 に対応し、TestPyPI自動公開ワークフローを追加しました。

## 変更内容

### 1. TestPyPI自動公開ワークフロー
- `.github/workflows/publish-test.yml` を追加
  - **トリガー**: mainブランチへのpush時 + 手動実行（workflow_dispatch）
  - **実行環境**: ubuntu-latest（パッケージアップロードのみなのでUbuntuで十分）
  - **処理フロー**:
    1. Python 3.12のセットアップ
    2. build・twineのインストール
    3. パッケージビルド (`python -m build`)
    4. パッケージチェック (`twine check dist/*`)
    5. TestPyPIへアップロード

### 2. ドキュメント更新
- `DEVELOPMENT.md` にTestPyPI公開セクションを追加
  - TestPyPI APIトークンの設定手順
  - TestPyPIからのインストール方法
  - バージョン管理の注意点

## セットアップ手順

このワークフローを有効化するには、以下のセットアップが必要です：

1. **TestPyPIアカウント作成**
   - https://test.pypi.org/ でアカウント登録

2. **APIトークン生成**
   - Account Settings → API tokens
   - "Add API token" でプロジェクト用トークン作成

3. **GitHub Secretsに登録**
   - リポジトリ Settings → Secrets and variables → Actions
   - New repository secret
   - Name: `TEST_PYPI_API_TOKEN`
   - Value: 生成したトークン

## TestPyPIからのインストール確認

マージ後、以下でTestPyPIから `screen-times` をインストール可能：

```bash
pip install --index-url https://test.pypi.org/simple/ \
            --extra-index-url https://pypi.org/simple/ \
            screen-times

screenocr --help
```

## 注意事項

- ⚠️ TestPyPIでは同じバージョン番号は1度しかアップロードできません
- 💡 開発版は `0.1.1.dev1` のような形式を推奨
- 🔒 `TEST_PYPI_API_TOKEN` シークレットの設定が必要（マージ前に設定してください）

## 次のステップ

- TestPyPIでの動作確認後、#41 で本番PyPI公開ワークフローを実装

## 関連Issue
Closes #40