### PR TITLE
feat: PyPI本番公開ワークフローとリリースプロセスを整備

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+# @format
+
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # 手動実行も可能
+
+jobs:
+  publish:
+    name: Publish package to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package
+        run: twine check dist/*
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-12-28
+
+### Added
+- Initial release of screen-times package
+- `screenocr` CLI command with subcommands: start, stop, status, split
+- macOS screen activity logging with OCR using Vision Framework
+- Automatic screenshot capture every 30 seconds
+- JSONL-based log storage with date-based organization
+- Task-based log splitting functionality
+- launchd agent for automatic background execution
+- Python 3.9-3.12 support
+- Comprehensive test suite with pytest
+- CI/CD with GitHub Actions (Ubuntu CI + macOS Build)
+- Code quality checks (black, flake8, mypy)
+- Pre-commit hooks for automatic code formatting
+- Package metadata and documentation for PyPI distribution
+
+### Technical Details
+- Package structure reorganized to src layout
+- Entry point configuration for pip installation
+- PyObjC integration for macOS frameworks (Cocoa, Vision, Quartz)
+- Automated testing with platform-specific skipif markers
+- Build verification on both Ubuntu and macOS runners
+- TestPyPI and PyPI publishing workflows
+
+[Unreleased]: https://github.com/koboriakira/screen-times/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/koboriakira/screen-times/releases/tag/v0.1.0

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -423,12 +423,57 @@ version = "0.1.0"  # 本番リリース用
 version = "0.1.1.dev1"  # 開発版
 ```
 
+### PyPI 本番公開
+
+`.github/workflows/publish.yml` でGitHub Releaseの作成時にPyPIへ自動公開。
+
+#### PyPI APIトークンの設定
+
+1. **PyPIアカウント作成**
+   - https://pypi.org/ でアカウント登録
+   - 2要素認証（2FA）を有効化することを推奨
+
+2. **APIトークン生成**
+   - Account Settings → API tokens
+   - "Add API token" でプロジェクト用トークン作成
+
+3. **GitHub Secretsに登録**
+   - リポジトリ Settings → Secrets and variables → Actions
+   - New repository secret
+   - Name: `PYPI_API_TOKEN`
+   - Value: 生成したトークン
+
+#### リリースプロセス
+
+詳細は [RELEASING.md](RELEASING.md) を参照。
+
+```bash
+# 1. バージョン更新
+# pyproject.toml の version を更新
+
+# 2. CHANGELOG.md を更新
+# 変更内容を記載
+
+# 3. GitHub Releaseを作成
+# https://github.com/koboriakira/screen-times/releases/new
+# タグ（例: v0.1.0）を作成してリリース
+
+# 4. 自動でPyPIに公開される
+```
+
+#### PyPIからのインストール
+
+```bash
+pip install screen-times
+screenocr --help
+```
+
 ## 貢献ガイドライン
 
 1. フィーチャーブランチを作成
-2. コミットメッセージは英語で簡潔に
+2. コミットメッセージはConventional Commitsの形式に従う
 3. テストを追加・更新
-4. `black`，`flake8` でフォーマット
+4. `black`、`flake8`、`mypy` でフォーマット・チェック
 5. プルリクエストを作成
 
 ---

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,143 @@
+# Release Process
+
+## Pre-release Checklist
+
+リリース前に以下を確認：
+
+- [ ] すべてのテストがパス（Ubuntu CI + macOS Build）
+- [ ] `CHANGELOG.md` が更新されている
+- [ ] `pyproject.toml` のバージョン番号が更新されている
+- [ ] `README.md` が最新の状態
+- [ ] TestPyPIでの動作確認済み
+
+## Release Steps
+
+### 1. バージョン番号の更新
+
+```toml
+# pyproject.toml
+version = "0.1.0"  # 適切なバージョンに更新
+```
+
+### 2. CHANGELOGの更新
+
+```bash
+# CHANGELOG.mdに変更内容を記載
+## [0.1.0] - 2025-12-28
+### Added
+- 新機能の説明
+### Changed
+- 変更内容の説明
+### Fixed
+- 修正内容の説明
+```
+
+### 3. コミット・プッシュ
+
+```bash
+git add pyproject.toml CHANGELOG.md
+git commit -m "chore: bump version to 0.1.0"
+git push origin main
+```
+
+### 4. GitHubでリリース作成
+
+1. https://github.com/koboriakira/screen-times/releases/new にアクセス
+2. 「Choose a tag」で新しいタグを作成（例: `v0.1.0`）
+3. リリースタイトル: `v0.1.0`
+4. リリースノート: CHANGELOGの内容をコピー
+5. 「Publish release」をクリック
+
+### 5. 自動公開の確認
+
+GitHub Releaseを作成すると、`.github/workflows/publish.yml` が自動的にトリガーされ、PyPIに公開されます。
+
+- Actions タブで実行状況を確認
+- PyPIページで公開を確認: https://pypi.org/project/screen-times/
+
+## Post-release
+
+リリース後の確認：
+
+### 1. インストールテスト
+
+```bash
+# 仮想環境を作成
+python -m venv test-env
+source test-env/bin/activate  # macOS/Linux
+# または
+test-env\Scripts\activate  # Windows
+
+# PyPIからインストール
+pip install screen-times
+
+# 動作確認
+screenocr --help
+screenocr status
+```
+
+### 2. ドキュメント確認
+
+- PyPIページの表示確認: https://pypi.org/project/screen-times/
+- READMEが正しく表示されているか
+- メタデータ（author, license, classifiersなど）が正しいか
+
+### 3. 次のバージョンへ
+
+開発を再開する場合は、次のバージョンに更新：
+
+```toml
+# pyproject.toml
+version = "0.1.1.dev0"  # 開発版として明示
+```
+
+## Manual Release (Alternative)
+
+GitHub Releaseを使わず、手動でPyPIに公開する場合：
+
+```bash
+# 1. ビルド
+python -m build
+
+# 2. パッケージチェック
+twine check dist/*
+
+# 3. TestPyPIで確認（オプション）
+twine upload --repository testpypi dist/*
+
+# 4. 本番PyPIに公開
+twine upload dist/*
+```
+
+## Troubleshooting
+
+### ビルドエラー
+
+```bash
+# キャッシュをクリア
+rm -rf dist/ build/ src/*.egg-info/
+python -m build
+```
+
+### アップロードエラー
+
+- APIトークンが正しく設定されているか確認
+- 同じバージョンが既に存在していないか確認
+- ネットワーク接続を確認
+
+### バージョン重複エラー
+
+PyPI（TestPyPI含む）では同じバージョンは1度しかアップロードできません：
+
+```bash
+# バージョンを上げてリトライ
+# pyproject.toml の version を更新
+python -m build
+twine upload dist/*
+```
+
+## Security
+
+- PyPI APIトークンは GitHub Secrets で管理
+- トークンはプロジェクト単位で発行（全プロジェクトアクセス可能なトークンは使用しない）
+- `.gitignore` に `dist/`, `build/`, `*.egg-info/` を追加済み


### PR DESCRIPTION
## 概要
Issue #28 に対応し、PyPI本番公開のワークフローとリリースプロセスを整備しました。

## 変更内容

### 1. PyPI本番公開ワークフロー
- `.github/workflows/publish.yml` を追加
  - **トリガー**: GitHub Release作成時（`release: published`） + 手動実行
  - **処理フロー**:
    1. Python 3.12のセットアップ
    2. build・twineのインストール
    3. パッケージビルド
    4. パッケージチェック（`twine check`）
    5. PyPIへアップロード

### 2. リリースプロセスドキュメント
- `RELEASING.md` を作成
  - **Pre-release Checklist**: リリース前に確認すべき項目
  - **Release Steps**: GitHub Releaseを使った自動公開手順
  - **Post-release**: リリース後のインストール確認手順
  - **Manual Release**: 手動でPyPIに公開する代替手順
  - **Troubleshooting**: よくあるエラーと対処法

### 3. 変更履歴ドキュメント
- `CHANGELOG.md` を作成
  - Keep a Changelog形式に準拠
  - Semantic Versioning対応
  - v0.1.0の変更内容を記載

### 4. DEVELOPMENT.md更新
- PyPI本番公開セクションを追加
  - APIトークン設定手順
  - リリースプロセスの概要
  - PyPIからのインストール方法

## セットアップ手順

このワークフローを有効化するには、以下のセットアップが必要です：

### 1. PyPI APIトークンの設定

1. **PyPIアカウント作成**
   - https://pypi.org/ でアカウント登録
   - 2要素認証（2FA）を有効化することを推奨

2. **APIトークン生成**
   - Account Settings → API tokens
   - "Add API token" でプロジェクト用トークン作成

3. **GitHub Secretsに登録**
   - リポジトリ Settings → Secrets and variables → Actions
   - New repository secret
   - Name: `PYPI_API_TOKEN`
   - Value: 生成したトークン

### 2. 初回リリース手順

マージ後、以下の手順でv0.1.0をリリースできます：

```bash
# 1. GitHub Releaseを作成
# https://github.com/koboriakira/screen-times/releases/new
# - Tag: v0.1.0
# - Title: v0.1.0
# - Description: CHANGELOG.mdの内容をコピー

# 2. "Publish release" をクリック
# → 自動的にPyPIへ公開される

# 3. PyPIで確認
# https://pypi.org/project/screen-times/

# 4. インストールテスト
pip install screen-times
screenocr --help
```

## リリースフロー

```
開発 → PR → main → GitHub Release → PyPI自動公開
              ↓
         TestPyPI（検証用）
```

## ファイル構成

- `.github/workflows/publish.yml` - PyPI公開ワークフロー
- `RELEASING.md` - リリースプロセスの詳細ドキュメント
- `CHANGELOG.md` - 変更履歴（Keep a Changelog形式）
- `DEVELOPMENT.md` - 開発者向けドキュメント（PyPI公開セクション追加）

## 注意事項

- 🔒 `PYPI_API_TOKEN` シークレットの設定が必要
- 📝 リリース前に必ず `RELEASING.md` のチェックリストを確認
- ⚠️ PyPIでは同じバージョンは1度しかアップロードできません
- ✅ TestPyPI（#40）で動作確認済み

## 次のステップ

1. このPRをマージ
2. `PYPI_API_TOKEN` をGitHub Secretsに設定
3. GitHub Releaseでv0.1.0を作成
4. 自動的にPyPIへ公開される
5. `pip install screen-times` で誰でもインストール可能に！

## 関連Issue
Closes #28