### PR TITLE
docs: PyPIとCI/CDステータスのバッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # screen-times
 
+[![PyPI version](https://badge.fury.io/py/screen-times.svg)](https://badge.fury.io/py/screen-times)
+[![Python Version](https://img.shields.io/pypi/pyversions/screen-times)](https://pypi.org/project/screen-times/)
+[![CI](https://github.com/koboriakira/screen-times/workflows/CI/badge.svg)](https://github.com/koboriakira/screen-times/actions/workflows/ci.yml)
+[![Build](https://github.com/koboriakira/screen-times/workflows/Build/badge.svg)](https://github.com/koboriakira/screen-times/actions/workflows/build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python Version](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/downloads/)
 [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)](https://www.apple.com/macos/)
 
 macOS上で毎分スクリーンショットを取得し、Vision FrameworkでOCR処理して、JSONL形式でアクティビティログを記録するシステムです。


### PR DESCRIPTION
## 概要
Issue #46 に対応し、README.mdにPyPIとCI/CDステータスのバッジを追加しました。

## 変更内容

### 追加したバッジ

1. **PyPIバージョンバッジ**
   - 現在公開中のバージョン（v0.1.0）を表示
   - PyPIページへのリンク

2. **Python対応バージョンバッジ**
   - 既存のバッジをPyPI連動に変更
   - PyPIメタデータから自動取得（Python 3.9-3.12）

3. **Ubuntu CIステータスバッジ**
   - CIワークフローの実行状態を表示
   - GitHub Actionsページへのリンク

4. **macOS Buildステータスバッジ**
   - macOSビルド検証の実行状態を表示
   - GitHub Actionsページへのリンク

## バッジの配置

```markdown
[![PyPI version](https://badge.fury.io/py/screen-times.svg)](https://badge.fury.io/py/screen-times)
[![Python Version](https://img.shields.io/pypi/pyversions/screen-times)](https://pypi.org/project/screen-times/)
[![CI](https://github.com/koboriakira/screen-times/workflows/CI/badge.svg)](https://github.com/koboriakira/screen-times/actions/workflows/ci.yml)
[![Build](https://github.com/koboriakira/screen-times/workflows/Build/badge.svg)](https://github.com/koboriakira/screen-times/actions/workflows/build.yml)
[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
[![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)](https://www.apple.com/macos/)
```

## 期待される効果

- ✅ PyPI公開されていることが一目で分かる
- ✅ 現在のバージョンが明確
- ✅ CI/CDが整備されていることをアピール
- ✅ 対応Pythonバージョンがリアルタイムで反映
- ✅ プロフェッショナルな印象

## プレビュー

マージ後、以下のURLでバッジの表示を確認できます：
- https://github.com/koboriakira/screen-times
- https://pypi.org/project/screen-times/

## 関連Issue
Closes #46