### PR TITLE
feat: Python 3.13と3.14への対応を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Desktop Environment :: Screen Savers",
     "Topic :: System :: Logging",
     "Topic :: Utilities",


### PR DESCRIPTION
## 概要
Issue #50 に対応し、Python 3.13と3.14への対応を追加しました。

## 変更内容

### 1. pyproject.tomlの更新

```toml
classifiers = [
    # ... existing
    "Programming Language :: Python :: 3.13",
    "Programming Language :: Python :: 3.14",
]
```

Python 3.13と3.14のclassifiersを追加し、PyPIページで対応バージョンとして表示されるようにしました。

### 2. CI/CDの更新

`.github/workflows/ci.yml` のマトリックステストに追加：

```yaml
strategy:
  matrix:
    python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
```

これにより、Python 3.13と3.14でも自動的にテストが実行されます。

## 期待される効果

### ✅ バッジの自動更新
PyPIバッジが **「Python 3.9-3.14」** と表示されるようになります（次回リリース後）：

[![Python Version](https://img.shields.io/pypi/pyversions/screen-times)](https://pypi.org/project/screen-times/)

### ✅ CI/CDによる検証
- Python 3.13と3.14でのテストが自動実行される
- 各バージョンでの互換性が保証される
- リグレッションを早期発見できる

### ✅ ユーザーへの対応
- 最新のPython環境でも安心して使用できる
- 長期的なメンテナンス性が向上
- より多くのユーザーに対応

## 技術的考慮事項

### 依存関係の互換性
- **PyObjC**: Python 3.13, 3.14をサポート済み
- **pytest**: 問題なし
- **black/flake8/mypy**: 問題なし

### テスト結果
このPRのCIで全バージョン（3.9-3.14）でのテストが実行されます。

## 次のステップ

1. このPRをマージ
2. 動作確認後、新しいバージョン（v0.1.1など）をリリース
3. PyPIに公開すると、バッジが「Python 3.9-3.14」に更新される

## 関連Issue
Closes #50