### PR TITLE
feat: JSONLファイルのサイズベース自動分割機能を実装

### DIFF
--- a/src/screen_times/screen_ocr_logger.py
+++ b/src/screen_times/screen_ocr_logger.py
@@ -218,8 +218,9 @@ class ScreenOCRLogger:
         """
         try:
             jsonl_path = self.jsonl_manager.get_current_jsonl_path(timestamp)
-            self.jsonl_manager.append_record(jsonl_path, timestamp, window, text)
-            return jsonl_path
+            # append_recordは実際に書き込んだファイルパスを返す（サイズ超過時は新ファイル）
+            actual_path = self.jsonl_manager.append_record(jsonl_path, timestamp, window, text)
+            return actual_path
         except Exception as e:
             if self.config.verbose:
                 print(f"Error: Failed to write to JSONL: {e}", file=sys.stderr)


### PR DESCRIPTION
## 概要
Issue #55 の実装です。JSONLファイルのサイズが100KBを超えたら自動的に新しいファイルを作成し、LLMのコンテキストウィンドウ（約50Kトークン）に適したサイズを維持します。

## 変更内容

### 1. ファイルサイズベースの自動分割
- `JsonlManager.MAX_FILE_SIZE_BYTES = 100 * 1024` 定数を追加
- `append_record()` メソッドでファイルサイズをチェック
- 100KB超過時に新しいタイムスタンプ付きファイルを自動作成
- 新しいファイルには適切なメタデータを書き込み

### 2. ファイル命名規則の変更
- **従来**: `2025-12-29.jsonl`（日付のみ）
- **新規**: `2025-12-29_HHMMSS.jsonl`（日付 + 時刻）
- `get_jsonl_path()` に `include_time` パラメータを追加

### 3. メソッドの改善
- `append_record()` が実際に書き込んだファイルパスを返すように変更
- `get_current_jsonl_path()` で同じ日付の複数ファイルから最新のものを選択
- `screen_ocr_logger.py` の `_save_to_jsonl()` で返り値を使用

### 4. テストの追加
- `test_get_jsonl_path_with_include_time`: 時刻付きファイル名生成のテスト
- `test_append_record_auto_split_on_size_exceeded`: サイズ超過時の自動分割テスト
- `test_append_record_no_split_when_size_ok`: サイズ未満時は分割しないテスト
- `test_get_current_jsonl_path_returns_latest_file`: 最新ファイル選択のテスト
- `test_append_record_returns_path`: 戻り値のテスト

### 5. 下位互換性
- 既存の日付ベースファイル（`2025-12-29.jsonl`）も引き続き読み込み可能
- 手動分割機能も正常に動作

## テスト結果
```
pytest tests/ -v
================================================ 43 passed =================================================
```

## 関連Issue
Closes #55